### PR TITLE
Hotfix/guild ids

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     - "443:80"
     restart: unless-stopped
     environment:
-    - TEST_GUILD_ID=''
     - LOGLEVEL=${LOGLEVEL}
     - DISCORDTOKEN=${DISCORDTOKEN}
     - CENSUS_TOKEN=${CENSUS_TOKEN}

--- a/src/main.py
+++ b/src/main.py
@@ -32,7 +32,7 @@ Initialize the bot
 discordClientToken = os.getenv('DISCORDTOKEN')
 Botdescription = "The serious bot for the casual Discord."
 
-if os.getenv('TEST_GUILD_ID') is not '':
+if os.getenv('TEST_GUILD_ID') is not None:
     bot = commands.Bot(
     command_prefix=commands.when_mentioned_or("?"), 
     description=Botdescription, 


### PR DESCRIPTION
The `test_guilds` argument in `commands.Bot` gets very upset if we put a variable in with `None` value - despite it defaulting to None :|
So this `if/else` statement defines the `commands.Bot`  block for both cases. Adding `TEST_GUILD_ID` values when one is present as an env var