### PR TITLE
fixed bug getting member name + discriminator

### DIFF
--- a/src/commands/new_discord_members.py
+++ b/src/commands/new_discord_members.py
@@ -40,15 +40,15 @@ class NewDiscordMembers(commands.Cog):
         for player in new_ps2_members:
 
             new_ps2_message = (
-                new_ps2_message + player.name + "#" + str(player.discriminator) + "\n"
+                new_ps2_message + str(player) + "\n"
             )
         for player in new_a3_members:
             new_a3_message = (
-                new_a3_message + player.name + "#" + str(player.discriminator) + "\n"
+                new_a3_message + str(player) + "\n"
             )
         for player in new_other_members:
             new_other_message = (
-                new_other_message + player.name + "#" + str(player.discriminator) + "\n"
+                new_other_message + str(player) + "\n"
             )
 
         Message = disnake.Embed(

--- a/src/discord_db.py
+++ b/src/discord_db.py
@@ -26,12 +26,10 @@ class DiscordMemberDB(commands.Cog):
         if db_entry is None:
             disc_obj = {}
             data = {}
-            discord_attrs = ["id", "name", "nick", "joined_at"]
+            discord_attrs = ["id", "nick", "joined_at"]
+            disc_obj["name"] = str(member)
             for count, ele in enumerate(discord_attrs):
                 disc_obj[ele] = str(getattr(member, ele))
-            disc_obj["name"] = (
-                str(disc_obj["name"]) + "#" + str(disc_obj["discriminator"])
-            )
             data["discord_user"] = disc_obj
             Database.insert_one("members", data)
         else:
@@ -71,11 +69,9 @@ class DiscordMemberDB(commands.Cog):
                 disc_obj = {}
                 data = {}
                 discord_attrs = ["id", "name", "nick", "joined_at"]
+                disc_obj["name"] = str(member)
                 for count, ele in enumerate(discord_attrs):
                     disc_obj[ele] = str(getattr(member, ele))
-                disc_obj["name"] = (
-                    str(disc_obj["name"]) + "#" + str(member.discriminator)
-                )
                 data["discord_user"] = disc_obj
                 all_mems.append(data)
         if len(all_mems) != 0:


### PR DESCRIPTION
member.discriminator is not a valid attribute.
However, `str(member)` returns member `name#1234`