### PR TITLE
Fixed the order of emoji reactions for voting

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -137,7 +137,8 @@ async def announce_event(
 
 @bot.message_command(name="Add Reactions")
 @commands.default_member_permissions(manage_messages=True)
-async def vote(inter: disnake.interactions.application_command.ApplicationCommandInteraction,
+@commands.bot_has_permissions(add_reactions=True)
+async def add_reactions(inter: disnake.interactions.application_command.ApplicationCommandInteraction,
                message: disnake.Message):
     emoji_list: list
 
@@ -152,12 +153,15 @@ async def vote(inter: disnake.interactions.application_command.ApplicationComman
                                           )
         return
 
-    discord_emojis = list(set(re.compile(r"<:.*:[0-9]*>").findall(message.content)))  # some magic to delete duplicates
-    emoji_list = emoji.distinct_emoji_list(message.content) + discord_emojis
+    discord_emojis = list(set(re.compile(r"<:.*:[0-9]*>").findall(message.content)))  # some sets to delete duplicates
+    emoji_list: list[str] = emoji.distinct_emoji_list(message.content) + discord_emojis
 
-    for item in emoji_list:
+    sorted_list = sorted(emoji_list, key=lambda i: message.content.rfind(i))
+
+    for item in sorted_list:
         await message.add_reaction(item)
-    await inter.edit_original_message("reacted with:" + str(emoji_list))
+
+    await inter.edit_original_message("reacted with:" + str(sorted_list) + "To message:" + message.jump_url)
 
 
 @aiocron.crontab("0 17 * * 5")


### PR DESCRIPTION
Now it will vote in order of **LAST** mention of the emoji and won't separate discord and Unicode emojis.

This was made and tested by commenting all the code related to DB to save development time. This shouldn't be a problem as this only affects a single method. Right?