### PR TITLE
Feature/online outfit memmber logging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,10 @@
-version: "3.x"
+version: "3.9"
 
 services:
   fubot:
     build: .
     image: fubot${ENVIRONMENT}
     container_name: fubot-${ENVIRONMENT}
-    ports:
-    - ${PORT_MAPPING}
     restart: unless-stopped
     environment:
     - LOGLEVEL=${LOGLEVEL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.x"
 
 services:
   fubot:

--- a/src/database_connector.py
+++ b/src/database_connector.py
@@ -28,6 +28,30 @@ class Database(object):
             logging.info("Database Initialized")
 
     @staticmethod
+    def init_timeseries_db(collection_name: str, collection_options: dict) -> pymongo.collection.Collection:
+        """
+        Get or create a timeseries collection in database.
+        If the timeseries exists, it oly makes sure that it's timeseries collection and nothing more
+        Parameters
+        ----------
+        collection_name: name of collection that will be used
+        collection_options: set of options this collection should have
+
+        Returns
+        -------
+            the timeseries collection with such name (and hopefully those options)
+        """
+        current_collection_options = Database.DATABASE[collection_name].options()
+
+        if collection_name not in Database.DATABASE.list_collection_names():
+            Database.DATABASE.create_collection(name=collection_name, timeseries=collection_options,
+                                 expireAfterSeconds=94608000)
+        elif "timeseries" not in current_collection_options.keys():
+            raise Exception(f"collection {collection_name} exists, but isn't timeseries")
+        collection: pymongo.collection.Collection = Database.DATABASE[collection_name]
+        return Database.DATABASE[collection_name]
+
+    @staticmethod
     def insert_one(collection, data):
         Database.DATABASE[collection].insert_one(data)
 

--- a/src/loggers/arma_server_logger.py
+++ b/src/loggers/arma_server_logger.py
@@ -2,7 +2,7 @@ import logging
 import os
 import datetime
 from steam import SteamQuery
-from ..database_connector import Database
+from database_connector import Database
 
 
 class ArmaLogger:

--- a/src/loggers/arma_server_logger.py
+++ b/src/loggers/arma_server_logger.py
@@ -2,7 +2,7 @@ import logging
 import os
 import datetime
 from steam import SteamQuery
-from database_connector import Database
+from ..database_connector import Database
 
 
 class ArmaLogger:

--- a/src/loggers/ps2_outfit_logger.py
+++ b/src/loggers/ps2_outfit_logger.py
@@ -1,0 +1,105 @@
+from ..database_connector import Database
+from auraxium import event, ps2
+from .. import census
+import logging
+import os
+import datetime
+import asyncio
+import time
+import typing
+import pymongo.collection
+import auraxium
+
+
+class Ps2OutfitPlayerLogger:
+    def __init__(
+            self,
+            db: Database,
+            saving_period: float = 5 * 60
+    ):
+        """
+        initializes ps2 logger.
+        Parameters
+        ----------
+        db: Database class instance to use
+        saving_period: time in seconds for fow frequently the data should be saved
+        """
+        self.saving_period: float = saving_period
+        FU_id = 37509488620602936
+        nFUc_id = 37558455247570544
+        vFUs_id = 37558804429669935
+        self._monitored_outfits: {int} = {FU_id, nFUc_id, vFUs_id}
+        self._max_player_count: typing.Dict[int: int] = dict.fromkeys(self._monitored_outfits, None)
+        self._last_player_count_save_time: float = .0
+        self.collection: pymongo.collection.Collection
+
+        db_collection_name = "ps2_outfit_player_log"
+        collection_options = {'timeField': 'timestamp', 'metaField': 'outfit', 'granularity': 'minutes'}
+
+        try:
+            self.collection = db.init_timeseries_db(db_collection_name, collection_options)
+            # This will create a task. currently, the loop will be run forever by the bot in disnake bots code
+            self.loop = asyncio.get_event_loop()
+            self.loop.create_task(self.ps2_outfit_events())
+        except Exception as exception:
+            logging.error("Failed to initialize PlanetSide outfit player logger", exc_info=exception)
+
+    def add_outfit(self, outfit_id: int):
+        """
+        Adds an outfit to the list of monitored outfits
+
+        Parameters
+        ----------
+        outfit_id: ID of outfit to monitor. Using ID as that's the only thing that doesn't really change
+        """
+        self._max_player_count[outfit_id] = None
+        self._monitored_outfits.add(outfit_id)
+
+    async def _save_player_count(self, outfit_id: int, current_count: int):
+        if not self._max_player_count[outfit_id] or current_count > self._max_player_count[outfit_id]:
+            self._max_player_count[outfit_id] = current_count
+
+        if time.time() > self._last_player_count_save_time + self.saving_period:
+            self._last_player_count_save_time = time.time()
+
+            tmp_store = self._max_player_count.copy()  # not 100% sure how async works in python, so going safe way
+            self._max_player_count = dict.fromkeys(self._monitored_outfits, None)
+            timestamp = datetime.datetime.utcnow()
+            for outfit in tmp_store:
+                if tmp_store[outfit]:
+                    self.collection.insert_one(
+                        {
+                            "metadata": {"outfit": outfit},
+                            "player_count": tmp_store[outfit],
+                            "timestamp": timestamp
+                        }
+                    )
+
+    async def ps2_outfit_events(self) -> None:
+        client = auraxium.event.EventClient(service_id=os.getenv('CENSUS_TOKEN'))
+
+        @client.trigger(event=event.PlayerLogout, worlds=[10])
+        async def logged_out(_event: event.PlayerLogout):
+            character = await client.get_by_id(ps2.Character, _event.character_id)
+            name: str = character.data.name.first
+            outfit = await character.outfit()
+            if not outfit:
+                return
+            if outfit.id in self._monitored_outfits:
+                await self._save_player_count(outfit.id, await census.get_online_outfit(outfit.id))
+            print(
+                f'{name} logged in at {character.data.times.last_login_date}, logged out at {_event.timestamp} and his '
+                f'outfit is {outfit.tag if outfit is not None else "non existent"} ')
+            # events.append(evt)
+
+        @client.trigger(event=event.PlayerLogin, worlds=[10])
+        async def logged_in(_event: event.PlayerLogin):
+            character = await client.get_by_id(ps2.Character, _event.character_id)
+            name: str = character.data.name.first
+            outfit = await character.outfit()
+            if not outfit:
+                return
+            if outfit.id in self._monitored_outfits:
+                await self._save_player_count(outfit.id, await census.get_online_outfit(outfit.id))
+            print(
+                f'{name} logged in at {_event.timestamp} and his outfit is {outfit.tag if outfit is not None else "non existent"} ')

--- a/src/loggers/ps2_outfit_logger.py
+++ b/src/loggers/ps2_outfit_logger.py
@@ -1,6 +1,6 @@
-from ..database_connector import Database
+from database_connector import Database
 from auraxium import event, ps2
-from .. import census
+import census
 import logging
 import os
 import datetime
@@ -39,10 +39,12 @@ class Ps2OutfitPlayerLogger:
         try:
             self.collection = db.init_timeseries_db(db_collection_name, collection_options)
             # This will create a task. currently, the loop will be run forever by the bot in disnake bots code
-            self.loop = asyncio.get_event_loop()
-            self.loop.create_task(self.ps2_outfit_events())
+            loop = asyncio.get_event_loop()
+            loop.create_task(self.ps2_outfit_events())
         except Exception as exception:
             logging.error("Failed to initialize PlanetSide outfit player logger", exc_info=exception)
+
+        loop.run_forever()
 
     def add_outfit(self, outfit_id: int):
         """
@@ -87,7 +89,7 @@ class Ps2OutfitPlayerLogger:
                 return
             if outfit.id in self._monitored_outfits:
                 await self._save_player_count(outfit.id, await census.get_online_outfit(outfit.id))
-            print(
+            logging.info(
                 f'{name} logged in at {character.data.times.last_login_date}, logged out at {_event.timestamp} and his '
                 f'outfit is {outfit.tag if outfit is not None else "non existent"} ')
             # events.append(evt)
@@ -101,5 +103,5 @@ class Ps2OutfitPlayerLogger:
                 return
             if outfit.id in self._monitored_outfits:
                 await self._save_player_count(outfit.id, await census.get_online_outfit(outfit.id))
-            print(
+            logging.info(
                 f'{name} logged in at {_event.timestamp} and his outfit is {outfit.tag if outfit is not None else "non existent"} ')

--- a/src/loggers/ps2_outfit_logger.py
+++ b/src/loggers/ps2_outfit_logger.py
@@ -44,7 +44,6 @@ class Ps2OutfitPlayerLogger:
         except Exception as exception:
             logging.error("Failed to initialize PlanetSide outfit player logger", exc_info=exception)
 
-        loop.run_forever()
 
     def add_outfit(self, outfit_id: int):
         """
@@ -83,25 +82,17 @@ class Ps2OutfitPlayerLogger:
         @client.trigger(event=event.PlayerLogout, worlds=[10])
         async def logged_out(_event: event.PlayerLogout):
             character = await client.get_by_id(ps2.Character, _event.character_id)
-            name: str = character.data.name.first
             outfit = await character.outfit()
             if not outfit:
                 return
             if outfit.id in self._monitored_outfits:
                 await self._save_player_count(outfit.id, await census.get_online_outfit(outfit.id))
-            logging.info(
-                f'{name} logged in at {character.data.times.last_login_date}, logged out at {_event.timestamp} and his '
-                f'outfit is {outfit.tag if outfit is not None else "non existent"} ')
-            # events.append(evt)
 
         @client.trigger(event=event.PlayerLogin, worlds=[10])
         async def logged_in(_event: event.PlayerLogin):
             character = await client.get_by_id(ps2.Character, _event.character_id)
-            name: str = character.data.name.first
             outfit = await character.outfit()
             if not outfit:
                 return
             if outfit.id in self._monitored_outfits:
                 await self._save_player_count(outfit.id, await census.get_online_outfit(outfit.id))
-            logging.info(
-                f'{name} logged in at {_event.timestamp} and his outfit is {outfit.tag if outfit is not None else "non existent"} ')

--- a/src/main.py
+++ b/src/main.py
@@ -8,11 +8,12 @@ from disnake.ext import commands
 import auraxium
 from auraxium import ps2
 import census
+import commands.new_discord_members as new_discord_members
 import commands.get_player as get_player
 import commands.get_outfit as get_outfit
 import commands.ops as ops
-import commands.new_discord_members as new_discord_members
 from database_connector import Database
+from loggers.ps2_outfit_logger import Ps2OutfitPlayerLogger
 from loggers.arma_server_logger import ArmaLogger
 import emoji
 import re
@@ -21,7 +22,6 @@ logging.basicConfig(level=logging.os.getenv('LOGLEVEL'), format='%(asctime)s %(f
                     datefmt='%m/%d/%Y %I:%M:%S %p')
 
 # Discord Intents
-
 intents = disnake.Intents.default()
 intents.members = True
 intents.message_content = True
@@ -32,6 +32,11 @@ intents.guilds = True
 discordClientToken = os.getenv('DISCORDTOKEN')
 Botdescription = "The serious bot for the casual Discord."
 
+
+Database.initialize()
+Ps2OutfitPlayerLogger(Database)
+arma_logger = ArmaLogger(Database)
+
 bot = commands.Bot(
     command_prefix=commands.when_mentioned_or("?"),
     description=Botdescription,
@@ -39,8 +44,6 @@ bot = commands.Bot(
     sync_commands_debug=False
 )
 
-Database.initialize()
-arma_logger = ArmaLogger(Database)
 
 
 @bot.event
@@ -190,3 +193,16 @@ bot.load_extension("commands.link_ps2_discord")
 bot.load_extension("discord_db")
 
 bot.run(discordClientToken)
+
+# # This is another way that we could try to run, if updates to bot break our setup.
+# loop = bot.loop #asyncio.get_event_loop()
+# try:
+#         loop.create_task(bot.start(discordClientToken))
+#         loop.create_task(ps2_outfit_events())
+#         loop.run_forever()
+#
+# except KeyboardInterrupt:
+#     loop.run_until_complete(bot.close())
+#     # cancel all tasks lingering
+# finally:
+#     loop.close()

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.27.1
-auraxium==0.2.1
+auraxium==0.2.2
 asyncio==3.4.3
 disnake==2.5.1
 emoji==1.7.0


### PR DESCRIPTION
Based on configured list of outfits, this monitors and saves maximum amount of people online once every 5 minutes. but the frequency can be easily changed later.
```json
{
  "timestamp": "2022-10-12T18:10:34.704+00:00",
  "metadata": {
    "outfit":  37509438620602936
  },
  "player_count": 21,
  "_id":  "6347004211f51da570f634d4"
}
```
it also looks like another Mega PR is going to master. although we could move arma logging out of the bot as that is in no way related or needs to be configured by the bot 