### PR TITLE
Added the squad markup reference command

### DIFF
--- a/src/commands/squad_markup.py
+++ b/src/commands/squad_markup.py
@@ -1,6 +1,7 @@
 import disnake
 from disnake.ext import commands
 
+
 class Ps2SquadMarkup(commands.Cog):
     """
     Class cog for ps2 squad markup help message.
@@ -27,18 +28,19 @@ class Ps2SquadMarkup(commands.Cog):
             "Delta": "`<font color=\"#ff0000\">✵ FU Delta Platoon/Voice Lead ✴</font>`"
         }
 
-        Message = disnake.Embed(
-        title="Squad Markup",
-        color=0x9E0B0F,
-        description="Copy and paste the following into your squad description."
+        message = disnake.Embed(
+            title="Squad Markup",
+            color=0x9E0B0F,
+            description="Copy and paste the following into your squad description."
         )
         for key, value in markup.items():
-            Message.add_field(
+            message.add_field(
                 name=f"{key} Squad",
                 value=value,
                 inline=False
             )
-        await inter.edit_original_message(embed=Message)
+        await inter.edit_original_message(embed=message)
+
 
 def setup(bot: commands.Bot):
     bot.add_cog(Ps2SquadMarkup(bot))

--- a/src/commands/squad_markup.py
+++ b/src/commands/squad_markup.py
@@ -1,0 +1,44 @@
+import disnake
+from disnake.ext import commands
+
+class Ps2SquadMarkup(commands.Cog):
+    """
+    Class cog for ps2 squad markup help message.
+    """
+
+    @commands.slash_command(dm_permission=True)
+    async def squad(self, inter):
+        pass
+
+    @squad.sub_command()
+    async def markup(
+            self,
+            inter: disnake.ApplicationCommandInteraction
+    ):
+        """
+        Print the markup for colourful squad names.
+        """
+        await inter.response.defer(ephemeral=True)
+
+        markup = {
+            "Alpha": "`<font color=\"#ff0000\">✵ FU Alpha Platoon/Voice Lead ✴</font>`",
+            "Bravo": "`<font color=\"#ff0000\">✵ FU Bravo Platoon/Voice Lead ✴</font>`",
+            "Charlie": "`<font color=\"#ff0000\">✵ FU Charlie Platoon/Voice Lead ✴</font>`",
+            "Delta": "`<font color=\"#ff0000\">✵ FU Delta Platoon/Voice Lead ✴</font>`"
+        }
+
+        Message = disnake.Embed(
+        title="Squad Markup",
+        color=0x9E0B0F,
+        description="Copy and paste the following into your squad description."
+        )
+        for key, value in markup.items():
+            Message.add_field(
+                name=f"{key} Squad",
+                value=value,
+                inline=False
+            )
+        await inter.edit_original_message(embed=Message)
+
+def setup(bot: commands.Bot):
+    bot.add_cog(Ps2SquadMarkup(bot))

--- a/src/main.py
+++ b/src/main.py
@@ -176,7 +176,9 @@ async def log_arma_server_status():
 bot.load_extension("commands.role_added")
 bot.load_extension("commands.new_discord_members")
 bot.load_extension("commands.link_ps2_discord")
+bot.load_extension("commands.squad_markup")
 bot.load_extension("discord_db")
+
 
 bot.run(discordClientToken)
 


### PR DESCRIPTION
Straightforward reference command - just prints the markup for colourful squad names as an ephemeral message to the user.

Has DM permissions too