### PR TITLE
cache char_ids to avoid rate limiting and re-enabled DB update

### DIFF
--- a/src/census.py
+++ b/src/census.py
@@ -55,14 +55,16 @@ class Census(object):
         return online_members
 
     @staticmethod
-    async def get_outfit(outfit_name: str = None, outfit_tag: str = None):
+    async def get_outfit(outfit_name: str = None, outfit_tag: str = None, synchro: bool = False):
         outfit = None
         try:
             if outfit_tag is not None:
-                logging.info(f"looking up PS2 Outfit details for: {outfit_tag}")
+                if synchro is False:
+                    logging.info(f"looking up PS2 Outfit details for: {outfit_tag}")
                 outfit = await Census.CLIENT.get(ps2.Outfit, alias_lower = outfit_tag.lower())
             elif outfit_name is not None:
-                logging.info(f"looking up PS2 Outfit details for: {outfit_name}")
+                if synchro is False:
+                    logging.info(f"looking up PS2 Outfit details for: {outfit_name}")
                 outfit = await Census.CLIENT.get(ps2.Outfit, name_lower = outfit_name.lower())
             else:
                 return None


### PR DESCRIPTION
Cache char_ids for tracked outfits to avoid rate limiting.
The cache updates every hour.

Also re-enabled the loop task in [ps2_outfit_members.py](https://github.com/Freelancers-Union/FUBot/compare/cache-outift-members?expand=1#diff-e55e3ce4ea1ae3480b8313c822d0503c2c13719a11530dfb677e1cc27ceb36bb) which has prevented the database from correctly registering outift leavers for some time.