### PR TITLE
Set logging driver to journlctl

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -6,6 +6,10 @@ services:
     image: fubot${ENVIRONMENT}
     container_name: fubot-${ENVIRONMENT}
     restart: unless-stopped
+    logging:
+      driver: "journald"
+      options:
+        tag: "{{.Name}}/{{.ImageID}}"
     environment:
     - LOGLEVEL=${LOGLEVEL}
     - DISCORDTOKEN=${DISCORDTOKEN}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,10 @@ services:
     image: fubot${ENVIRONMENT}
     container_name: fubot-${ENVIRONMENT}
     restart: unless-stopped
+    logging:
+      driver: "journald"
+      options:
+        tag: "{{.Name}}/{{.ImageID}}"
     environment:
     - LOGLEVEL=${LOGLEVEL}
     - DISCORDTOKEN=${DISCORDTOKEN}


### PR DESCRIPTION
Default docker logs don't rotate, so I propose that we use journalctl driver that rotates (deletes) old logs so log files won't will the disk.  

interacting with logs won't change, except we will be able to  also leverage power of journalctl.
we will now be able to check logs like this:
`journalctl CONTAINER_NAME=fubot-prod`

https://docs.docker.com/config/containers/logging/journald/