### PR TITLE
get_server_info command added for Arma Cog

### DIFF
--- a/src/commands/arma/server_query.py
+++ b/src/commands/arma/server_query.py
@@ -1,0 +1,16 @@
+import asyncio
+import logging
+import os
+from steam import SteamQuery
+
+async def get_server_info():
+    try:
+        server_query = SteamQuery(os.getenv("ARMA_HOST"), int(os.getenv("ARMA_QUERY_PORT")))
+        response = server_query.query_server_info()
+        player_count: int = response.get("players")
+        description = response.get("description")
+        return f"**Current player count**: {player_count}\n**Mission/Status**: {description}"
+    except Exception as ex:
+        logging.exception(f"Failed to get Arma server info: {ex}")
+        return f"Failed to get server info, maybe it's offline?"
+

--- a/src/commands/arma_cog.py
+++ b/src/commands/arma_cog.py
@@ -5,6 +5,7 @@ import logging
 
 from commands.arma.get_db import get_players, get_mapping, add_mapping
 from commands.arma.upload_map import upload_mission
+from commands.arma.server_query import get_server_info
 
 
 class ArmACog(commands.Cog):
@@ -122,6 +123,15 @@ class ArmACog(commands.Cog):
 
         message = await add_mapping(username, discord_id, steam_id)
 
+        await inter.edit_original_message(content=message)
+
+    @arma.sub_command()
+    async def get_server_info(self, inter: disnake.ApplicationCommandInteraction):
+        """
+        Display the server info.
+        """
+        await inter.response.defer(ephemeral=False)
+        message = await get_server_info()
         await inter.edit_original_message(content=message)
 
 

--- a/src/loggers/arma_server_logger.py
+++ b/src/loggers/arma_server_logger.py
@@ -6,6 +6,8 @@ from disnake.ext.commands import Cog, Bot
 from disnake.ext import tasks
 from database.models.arma import OnlineFUArmaPlayers, ArmAPlayer
 
+### DEPRECATED ###
+### Please use the get_server_info command from commands/arma/server_query.py instead ###
 
 class ArmALogger(Cog):
 


### PR DESCRIPTION
Just adding a short new command, same basic syntax as arma_server_logger, but it's just returning the active player count and mission/server status.