### PR TITLE
Fixing a3-onboarding and leaderboard

### DIFF
--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -28,6 +28,7 @@ jobs:
       ARMA_SFTP_PASSWORD: ${{ secrets.ARMA_SFTP_PASSWORD }}
       ARMA_SFTP_MAP_PATH: ${{ secrets.ARMA_SFTP_MAP_PATH }}
       METABASE_KEY: ${{ secrets.METABASE_KEY }}
+      METABASE_URL: ${{ secrets.METABASE_URL }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -35,6 +35,7 @@ jobs:
       ARMA_SFTP_PASSWORD: ${{ secrets.ARMA_SFTP_PASSWORD }}
       ARMA_SFTP_MAP_PATH: ${{ secrets.ARMA_SFTP_MAP_PATH }}
       METABASE_KEY: ${{ secrets.METABASE_KEY }}
+      METABASE_URL: ${{ secrets.METABASE_URL }}
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -27,5 +27,6 @@ services:
     - ARMA_SFTP_PASSWORD=${ARMA_SFTP_PASSWORD}
     - ARMA_SFTP_MAP_PATH=${ARMA_SFTP_MAP_PATH}
     - METABASE_KEY=${METABASE_KEY}
+    - METABASE_URL=${METABASE_URL}
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,5 +27,6 @@ services:
     - ARMA_SFTP_PASSWORD=${ARMA_SFTP_PASSWORD}
     - ARMA_SFTP_MAP_PATH=${ARMA_SFTP_MAP_PATH}
     - METABASE_KEY=${METABASE_KEY}
+    - METABASE_URL=${METABASE_URL}
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/src/main.py
+++ b/src/main.py
@@ -71,7 +71,7 @@ async def on_connect():
     # bot.load_extension("loggers.ps2_outfit_online_logger")
     # bot.load_extension("loggers.arma_server_logger")
     bot.load_extension("send_intro")
-    bot.load_extension("helpers.sync_commands")
+    # bot.load_extension("helpers.sync_commands")
     bot.load_extension("services.a3_onboarding")
     bot.load_extension("services.ps2_leader_messages")
 


### PR DESCRIPTION
A faulty import of `helpers.sync_commands` in `main.py` was causing `services.a3_onboarding` and `services.ps2_leader_messages` to not get loaded correctly. `sync_commands` is effectively an empty file with everything commented out, which was throwing an error and stopping subsequent imports.

METABASE_URL was added as an additional env variable to address FUBot no longer having access to the leaderboard data (since the migration to the A3 server).